### PR TITLE
Use proper case for TAP name

### DIFF
--- a/TAP.tex
+++ b/TAP.tex
@@ -46,7 +46,7 @@
 \begin{document}
 
 \begin{abstract}
-The table access protocol (TAP) defines a service protocol for accessing general 
+The Table Access Protocol (TAP) defines a service protocol for accessing general 
 table data, including astronomical catalogs as well as general database tables. 
 Access is provided for both database and table metadata as well as for actual 
 table data. This version of the protocol includes support for multiple query 


### PR DESCRIPTION
The first usage of `Table Access Protocol` here should probably be in proper-case, similar to Line 90.